### PR TITLE
UINV-64 Status field is disabled if status is Paid

### DIFF
--- a/src/invoices/InvoiceForm/InvoiceForm.js
+++ b/src/invoices/InvoiceForm/InvoiceForm.js
@@ -161,6 +161,7 @@ class InvoiceForm extends Component {
     const metadata = initialValues.metadata;
     const approvedBy = get(initialValues, 'approvedBy');
     const isEditMode = Boolean(initialValues.id);
+    const isStatusPaid = isPaid(initialValues.status);
 
     const activeVendors = this.getActiveVendors();
     const selectedVendor = find(activeVendors, { id: get(formValues, 'vendorId') });
@@ -223,6 +224,7 @@ class InvoiceForm extends Component {
                       <Col data-test-col-status xs={3}>
                         <FieldSelection
                           dataOptions={statusOptions}
+                          disabled={isStatusPaid}
                           id="invoice-status"
                           label={<FormattedMessage id="ui-invoice.invoice.details.information.status" />}
                           name="status"


### PR DESCRIPTION
## Purpose
Currently, User can edit an Invoice and transition from Paid status to Approved. This is an invalid invoice transition. User should always use Approved button to activate those statuses rather than editing the invoice status manually
https://issues.folio.org/browse/UINV-64
## Approach
Check invoice status on Edit screen. If current status 'Paid', the field should be disabled.
## Screenshot
![image](https://user-images.githubusercontent.com/43407139/65222262-5a4f3c00-dac7-11e9-83e4-cd2e7d1a898a.png)
## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
