### PR TITLE
Remove explicit fake-xml-http-request in advance for the stripes-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,6 @@
   "optionalDependencies": {
     "@folio/plugin-find-po-line": "^1.0.0"
   },
-  "resolutions": {
-    "fake-xml-http-request": "2.0.0"
-  },
   "stripes": {
     "actsAs": ["app", "settings"],
     "displayName": "ui-invoice.meta.title",


### PR DESCRIPTION
Having multiple versions of the fake-xml-http-request can prevent patching.