### PR TITLE
UINV-94 Not able to create invoice lines with $0 sub-totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bug Fixes
 * [UINV-93](https://issues.folio.org/browse/UINV-93) Address lookup not working in Invoices
+* [UINV-94](https://issues.folio.org/browse/UINV-94) Not able to create invoice lines with $0 subtotal
 
 ## [1.2.0](https://github.com/folio-org/ui-invoice/tree/v1.2.0) (2019-12-04)
 [Full Changelog](https://github.com/folio-org/ui-invoice/compare/v1.1.0...v1.2.0)

--- a/src/invoices/InvoiceLineForm/InvoiceLineForm.js
+++ b/src/invoices/InvoiceLineForm/InvoiceLineForm.js
@@ -31,6 +31,7 @@ import {
   FieldSelection,
   FundDistributionFields,
   parseNumberFieldValue,
+  validateRequiredNotNegative,
 } from '@folio/stripes-acq-components';
 
 import {
@@ -222,7 +223,7 @@ class InvoiceLineForm extends Component {
                           required
                           type="number"
                           parse={parseNumberFieldValue}
-                          validate={validateRequired}
+                          validate={validateRequiredNotNegative}
                         />
                       </Col>
                       <Col data-test-col-invoice-line-vendor-ref-no xs={3}>


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
A sub total should be required for all invoice lines. However, there are use cases for which the user will input a value of 0 for the invoice subtotal amount and possibly have no adjustments either.
https://issues.folio.org/browse/UINV-94
## Approach
Not negative validation usage from `stripes-acq-components`
#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
