### PR TITLE
UINV-460 Invoices with `exportToAccounting` but no `accountingCode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## (IN PROGRESS)
 
 * Unpin `@rehooks/local-storage` now that it's no longer broken. Refs UINV-456.
+* Invoices with `exportToAccounting` but no `accountingCode`. Refs UINV-460.
 
 ## [4.0.0](https://github.com/folio-org/ui-invoice/tree/v4.0.0) (2023-02-22)
 [Full Changelog](https://github.com/folio-org/ui-invoice/compare/v3.3.1...v4.0.0)

--- a/src/common/hooks/index.js
+++ b/src/common/hooks/index.js
@@ -1,5 +1,6 @@
-export * from './useBatchGroup';
 export * from './useAddressCategories';
+export * from './useBatchGroup';
+export * from './useConfigsAdjustments';
 export * from './useFundDistributionValidation';
 export * from './useInvoice';
 export * from './useInvoiceMutation';

--- a/src/common/hooks/useConfigsAdjustments/index.js
+++ b/src/common/hooks/useConfigsAdjustments/index.js
@@ -1,0 +1,1 @@
+export { useConfigsAdjustments } from './useConfigsAdjustments';

--- a/src/common/hooks/useConfigsAdjustments/useConfigsAdjustments.js
+++ b/src/common/hooks/useConfigsAdjustments/useConfigsAdjustments.js
@@ -1,0 +1,30 @@
+import { useQuery } from 'react-query';
+
+import { useNamespace, useOkapiKy } from '@folio/stripes/core';
+import { CONFIG_API, LIMIT_MAX } from '@folio/stripes-acq-components';
+
+import {
+  CONFIG_MODULE_INVOICE,
+  CONFIG_NAME_ADJUSTMENTS,
+} from '../../constants';
+
+export const useConfigsAdjustments = (options = {}) => {
+  const ky = useOkapiKy();
+  const [namespace] = useNamespace({ key: 'configurations-invoice-adjustments' });
+
+  const searchParams = {
+    limit: LIMIT_MAX,
+    query: `(module=${CONFIG_MODULE_INVOICE} and configName=${CONFIG_NAME_ADJUSTMENTS}) sortby code`,
+  };
+
+  const { isLoading, data } = useQuery(
+    [namespace],
+    () => ky.get(CONFIG_API, { searchParams }).json(),
+    options,
+  );
+
+  return ({
+    isLoading,
+    adjustments: data?.configs || [],
+  });
+};

--- a/src/common/hooks/useConfigsAdjustments/useConfigsAdjustments.test.js
+++ b/src/common/hooks/useConfigsAdjustments/useConfigsAdjustments.test.js
@@ -1,0 +1,37 @@
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useOkapiKy } from '@folio/stripes/core';
+
+import { useConfigsAdjustments } from './useConfigsAdjustments';
+
+const queryClient = new QueryClient();
+
+// eslint-disable-next-line react/prop-types
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+const configValue = '{"alwaysShow":true,"exportToAccounting":true,"prorate":"Not prorated","relationToTotal":"In addition to","type":"Amount","description":"Test","defaultAmount":"100"}';
+
+describe('useConfigsAdjustments', () => {
+  it('should return invoice adjustments configurations', async () => {
+    useOkapiKy.mockClear().mockReturnValue({
+      get: () => ({
+        json: async () => ({
+          configs: [{ value: configValue }],
+        }),
+      }),
+    });
+
+    const { result, waitFor } = renderHook(() => useConfigsAdjustments(), { wrapper });
+
+    await waitFor(() => {
+      return !result.current.isLoading;
+    });
+
+    expect(result.current.adjustments[0].value).toEqual(configValue);
+  });
+});

--- a/src/invoices/InvoiceForm/InvoiceForm.js
+++ b/src/invoices/InvoiceForm/InvoiceForm.js
@@ -8,6 +8,7 @@ import {
   find,
   get,
   isNumber,
+  noop,
 } from 'lodash';
 
 import {
@@ -78,7 +79,7 @@ const MANAGE_UNITS_PERM = 'invoices.acquisitions-units-assignments.manage';
 
 const InvoiceForm = ({
   batchGroups,
-  form: { batch, change, mutators: { push } },
+  form,
   handleSubmit,
   initialValues,
   initialVendor,
@@ -92,6 +93,14 @@ const InvoiceForm = ({
 }) => {
   const history = useHistory();
   const accordionStatusRef = useRef();
+
+  const {
+    batch,
+    change,
+    mutators: { push },
+    registerField,
+  } = form;
+
   const filledBillTo = values?.billTo;
   const filledVendorId = values?.vendorId;
   const filledCurrency = values?.currency;
@@ -116,6 +125,16 @@ const InvoiceForm = ({
   } = initialValues;
   const [selectedVendor, setSelectedVendor] = useState();
   const [isLockTotalAmountEnabled, setLockTotalAmountEnabled] = useState(isNumber(lockTotal));
+
+  useEffect(() => {
+    const unregisterAccountingCodeField = registerField('accountingCode', noop);
+
+    return () => {
+      unregisterAccountingCodeField();
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const selectVendor = useCallback((vendor) => {
     if (selectedVendor?.id !== vendor.id) {
       setSelectedVendor(vendor);

--- a/src/invoices/InvoiceForm/InvoiceFormContainer.test.js
+++ b/src/invoices/InvoiceForm/InvoiceFormContainer.test.js
@@ -1,14 +1,9 @@
 import React from 'react';
-import { QueryClient, QueryClientProvider } from 'react-query';
 import { render, screen, act, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import user from '@testing-library/user-event';
 
-import { useOkapiKy } from '@folio/stripes/core';
-import {
-  CONFIG_API,
-  useOrganization,
-} from '@folio/stripes-acq-components';
+import { useOrganization } from '@folio/stripes-acq-components';
 
 import {
   match,
@@ -37,10 +32,11 @@ jest.mock('./utils', () => ({
 }));
 jest.mock('../../common/hooks', () => ({
   ...jest.requireActual('../../common/hooks'),
+  useConfigsAdjustments: jest.fn().mockReturnValue({ adjustments: [], isLoading: false }),
   useInvoice: jest.fn(),
-  useOrderLines: () => jest.fn().mockReturnValue({ orderLines: [], isLoading: false }),
-  useOrders: () => jest.fn().mockReturnValue({ orders: [], isLoading: false }),
-  useInvoiceLineMutation: () => jest.fn().mockReturnValue({ mutateInvoiceLine: jest.fn() }),
+  useOrderLines: jest.fn().mockReturnValue({ orderLines: [], isLoading: false }),
+  useOrders: jest.fn().mockReturnValue({ orders: [], isLoading: false }),
+  useInvoiceLineMutation: jest.fn().mockReturnValue({ mutateInvoiceLine: jest.fn() }),
 }));
 
 const mutatorMock = {
@@ -72,38 +68,13 @@ const defaultProps = {
   stripes: { currency: 'USD' },
   onCancel: jest.fn(),
 };
-
-const queryClient = new QueryClient();
-
-// eslint-disable-next-line react/prop-types
-const wrapper = ({ children }) => (
-  <MemoryRouter>
-    <QueryClientProvider client={queryClient}>
-      {children}
-    </QueryClientProvider>
-  </MemoryRouter>
-);
-
 const renderInvoiceFormContainer = (props = defaultProps) => render(
   <InvoiceFormContainerComponent {...props} />,
-  { wrapper },
+  { wrapper: MemoryRouter },
 );
-
-const kyMock = {
-  get: jest.fn((url) => ({
-    json: async () => {
-      if (url.startsWith(CONFIG_API)) {
-        return { adjustments: [], isLoading: false };
-      }
-
-      return {};
-    },
-  })),
-};
 
 describe('InvoiceFormContainer', () => {
   beforeEach(() => {
-    useOkapiKy.mockClear().mockReturnValue(kyMock);
     useInvoice.mockClear().mockReturnValue({ isInvoiceLoading: false, invoice });
     useOrganization.mockClear().mockReturnValue({ isLoading: false, organization: vendor });
   });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UINV-460

In the invoice form `accountingCode` field is not registered in the `final-form`, it only contains a value, that might be included in the payload. But it may happen that unregistered fields are reset to an initial state.

<details>
<summary>Preview</summary>

![reproduction-min](https://user-images.githubusercontent.com/88109087/223103027-5cb963cc-8942-4679-a479-970c78a2929e.gif)

</details>

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Register `accountingCode` field in the Invoice form.

Additional scope:
- optimize data passed to the form component to reduce unnecessary renders
- use `react-query` hook (`useConfigsAdjustments`) to get invoice adjustments configs instead of mutator (resources always return a new list of records instead of reference to existing one)
- add/update jest unit tests

<details>
<summary>Preview</summary>

![chrome_JEgWhDrhRX](https://user-images.githubusercontent.com/88109087/223104496-b7f2cf54-44b8-4cd6-90a7-0cf5d88dec34.gif)

</details>

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
