### PR TITLE
UINV-458 Provide content to the permissioned route as a `children` prop

### DIFF
--- a/src/settings/adjustments/SettingsAdjustments.js
+++ b/src/settings/adjustments/SettingsAdjustments.js
@@ -5,6 +5,7 @@ import {
 } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
+import { withRouter } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
 
@@ -20,6 +21,8 @@ import SettingsAdjustmentsViewContainer from './SettingsAdjustmentsView';
 import { getSettingsAdjustmentsList } from './util';
 
 export const RETURN_LINK_LABEL_ID = 'ui-invoice.settings.adjustments.label';
+
+const SettingsAdjustmentsEditor = withRouter(SettingsAdjustmentsEditorContainer);
 
 function SettingsAdjustments({ history, label, match: { path }, resources }) {
   const closePane = useCallback(() => {
@@ -53,15 +56,13 @@ function SettingsAdjustments({ history, label, match: { path }, resources }) {
         exact
         perm="ui-invoice.settings.all"
         path={`${path}/create`}
-        render={(props) => (
-          <SettingsAdjustmentsEditorContainer
-            {...props}
-            close={closePane}
-          />
-        )}
         returnLink={path}
         returnLinkLabelId={RETURN_LINK_LABEL_ID}
-      />
+      >
+        <SettingsAdjustmentsEditor
+          close={closePane}
+        />
+      </PermissionedRoute>
       <Route
         path={`${path}/:id/view`}
         render={(props) => (
@@ -77,15 +78,13 @@ function SettingsAdjustments({ history, label, match: { path }, resources }) {
         exact
         perm="ui-invoice.settings.all"
         path={`${path}/:id/edit`}
-        render={(props) => (
-          <SettingsAdjustmentsEditorContainer
-            {...props}
-            close={closePane}
-          />
-        )}
         returnLink={path}
         returnLinkLabelId={RETURN_LINK_LABEL_ID}
-      />
+      >
+        <SettingsAdjustmentsEditor
+          close={closePane}
+        />
+      </PermissionedRoute>
     </Switch>
   );
 }

--- a/src/settings/adjustments/SettingsAdjustments.js
+++ b/src/settings/adjustments/SettingsAdjustments.js
@@ -2,10 +2,10 @@ import React, { useCallback } from 'react';
 import {
   Route,
   Switch,
+  withRouter,
 } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
 
@@ -59,9 +59,7 @@ function SettingsAdjustments({ history, label, match: { path }, resources }) {
         returnLink={path}
         returnLinkLabelId={RETURN_LINK_LABEL_ID}
       >
-        <SettingsAdjustmentsEditor
-          close={closePane}
-        />
+        <SettingsAdjustmentsEditor close={closePane} />
       </PermissionedRoute>
       <Route
         path={`${path}/:id/view`}
@@ -81,9 +79,7 @@ function SettingsAdjustments({ history, label, match: { path }, resources }) {
         returnLink={path}
         returnLinkLabelId={RETURN_LINK_LABEL_ID}
       >
-        <SettingsAdjustmentsEditor
-          close={closePane}
-        />
+        <SettingsAdjustmentsEditor close={closePane} />
       </PermissionedRoute>
     </Switch>
   );


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UINV-458

`PermissionedRoute` doesn't accept `render` prop as the default `Route` from `react-router`, instead content of the route should be passed as a `children`

initial PR: #734

## Screenshot
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

https://github.com/folio-org/ui-invoice/assets/88109087/aa708b86-d66b-49f1-939c-03c430656761


<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
