### PR TITLE
UINV-575: Display full drop-down list of organization account numbers regardless of `Active` status case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Display selected version in Invoice view. Refs UINV-470.
 * Display selected version in Invoice line view. Refs UINV-553.
 * Display vendor details and extended info for version history. Refs UINV-569.
-* Display full drop-down list of organization account numbers regardless of `Active` status case. Refs UINV-575.
+* Display full drop-down list of organization account numbers regardless of `Active` status case. Fixes UINV-575.
 
 ## [6.1.1](https://github.com/folio-org/ui-invoice/tree/v6.1.1) (2024-11-27)
 [Full Changelog](https://github.com/folio-org/ui-invoice/compare/v6.1.0...v6.1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Display selected version in Invoice view. Refs UINV-470.
 * Display selected version in Invoice line view. Refs UINV-553.
 * Display vendor details and extended info for version history. Refs UINV-569.
+* Display full drop-down list of organization account numbers regardless of `Active` status case. Refs UINV-575.
 
 ## [6.1.1](https://github.com/folio-org/ui-invoice/tree/v6.1.1) (2024-11-27)
 [Full Changelog](https://github.com/folio-org/ui-invoice/compare/v6.1.0...v6.1.1)

--- a/src/invoices/InvoiceLineForm/InvoiceLineForm.js
+++ b/src/invoices/InvoiceLineForm/InvoiceLineForm.js
@@ -179,7 +179,8 @@ const InvoiceLineForm = ({
 
   const isSelectedAccountInactive = useMemo(() => {
     return accounts.some(({ accountNo, accountStatus }) => {
-      return accountNo === currentAccountNumber && accountStatus === ACCOUNT_STATUS.INACTIVE;
+      return accountNo === currentAccountNumber
+        && accountStatus.toLowerCase() === ACCOUNT_STATUS.INACTIVE.toLowerCase();
     });
   }, [accounts, currentAccountNumber]);
 

--- a/src/invoices/utils.js
+++ b/src/invoices/utils.js
@@ -126,7 +126,7 @@ export const getCommonInvoiceLinesFormatter = (currency, ordersMap, orderlinesMa
 export const getActiveAccountNumberOptions = ({ accounts = [], initialAccountNumber, formatMessage }) => {
   const message = ` - ${formatMessage({ id: 'ui-invoice.inactive' })}`;
   const activeAccounts = accounts.filter(({ accountStatus, accountNo }) => {
-    return accountStatus === ACTIVE || accountNo === initialAccountNumber;
+    return accountStatus.toLowerCase() === ACTIVE.toLowerCase() || accountNo === initialAccountNumber;
   });
 
   return uniq(activeAccounts.map(({ name, accountNo, accountStatus }) => ({


### PR DESCRIPTION
## Purpose
* User should be able to manually select any Active account number from the Organization related to that invoice.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Some organizations are created via API and accounts' status iscreated with small letter `active` instead of `Active`.
* Сonvert accounts statuses to lower case in order to make comparison more flexible.

## Links
[UINV-575](https://folio-org.atlassian.net/browse/UINV-575)

## Screenshots
https://github.com/user-attachments/assets/aca8c978-04ca-4953-80cd-43010f2da092

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
