### PR TITLE
UINV-595 Provide invoice ID on 'onCancel' call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 7.1.0 (IN PROGRESS)
 
+* Provide an invoice ID on form close handler. Refs UINV-595.
+
 ## [7.0.2](https://github.com/folio-org/ui-invoice/tree/v7.0.2) (2025-04-01)
 [Full Changelog](https://github.com/folio-org/ui-invoice/compare/v7.0.1...v7.0.2)
 

--- a/src/invoices/InvoiceDetails/DocumentsDetails/__snapshots__/DocumentsDetails.test.js.snap
+++ b/src/invoices/InvoiceDetails/DocumentsDetails/__snapshots__/DocumentsDetails.test.js.snap
@@ -16,7 +16,6 @@ exports[`DocumentsDetails should render invoice documents 1`] = `
       <div
         class="mclEmptyMessage"
         style="min-width: 200px;"
-        tabindex="0"
       >
         stripes-components.tableEmpty
       </div>

--- a/src/invoices/InvoiceForm/InvoiceForm.js
+++ b/src/invoices/InvoiceForm/InvoiceForm.js
@@ -100,7 +100,7 @@ const InvoiceForm = ({
   initialVendor = {},
   isCreateFromOrder = false,
   isSubmitDisabled: isSubmitDisabledProp,
-  onCancel: closeForm,
+  onCancel,
   parentResources,
   pristine,
   saveButtonLabelId = 'stripes-components.saveAndClose',
@@ -155,6 +155,10 @@ const InvoiceForm = ({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const closeForm = useCallback(() => {
+    onCancel(id);
+  }, [id, onCancel]);
 
   const selectVendor = useCallback((vendor) => {
     if (selectedVendor?.id !== vendor.id) {

--- a/src/invoices/InvoiceForm/InvoiceForm.js
+++ b/src/invoices/InvoiceForm/InvoiceForm.js
@@ -80,9 +80,9 @@ import {
 } from '../../common/utils';
 import AdjustmentsForm from '../AdjustmentsForm';
 import { SECTIONS_INVOICE_FORM as SECTIONS } from '../constants';
-import InvoiceLinksForm from './InvoiceLinksForm';
 import FieldBatchGroup from './FieldBatchGroup';
 import InvoiceDocumentsForm from './InvoiceDocumentsForm';
+import InvoiceLinksForm from './InvoiceLinksForm';
 import { validateAccountingCode } from './utils';
 
 import invoiceCss from '../Invoice.css';


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UINV-595

Providing `onCancel` directly as a prop to the children components causes an issue in the routing: `onCancel` expect an optional argument - invoice ID - but in some cases get an event instead.

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
