### PR TITLE
UINV-579 Update confirmation modal for currency change

### DIFF
--- a/src/invoices/InvoiceForm/InvoiceForm.js
+++ b/src/invoices/InvoiceForm/InvoiceForm.js
@@ -156,6 +156,7 @@ const InvoiceForm = ({
   } = initialValues;
   const [selectedVendor, setSelectedVendor] = useState();
   const [isLockTotalAmountEnabled, setIsLockTotalAmountEnabled] = useState(isNumber(lockTotal));
+  const [isUserAcknowledgedAboutCurrencyChange, setIsUserAcknowledgedAboutCurrencyChange] = useState(false);
 
   useEffect(() => {
     const unregisterAccountingCodeField = registerField('accountingCode', noop);
@@ -324,22 +325,22 @@ const InvoiceForm = ({
       cb?.();
     };
 
-    const { initial, modified } = getFieldState(field);
+    const { initial } = getFieldState(field);
 
     const isUserShouldBeAcknowledged = (
       isCreateFromOrder
-      && !modified
       && value !== initial
+      && !isUserAcknowledgedAboutCurrencyChange
     );
 
     handleChange(value);
 
     if (isUserShouldBeAcknowledged) {
       await initCurrencyChangeConfirmModal()
-        .then(noop)
+        .then(() => setIsUserAcknowledgedAboutCurrencyChange(true))
         .catch(() => handleChange(initial));
     }
-  }, [change, getFieldState, initCurrencyChangeConfirmModal, isCreateFromOrder]);
+  }, [change, getFieldState, initCurrencyChangeConfirmModal, isCreateFromOrder, isUserAcknowledgedAboutCurrencyChange]);
 
   const shortcuts = [
     {
@@ -758,6 +759,7 @@ const InvoiceForm = ({
             </Row>
 
             <ConfirmationModal
+              confirmLabel={<FormattedMessage id="stripes-core.button.confirm" />}
               id="confirm-currency-change-modal"
               heading={<FormattedMessage id="ui-invoice.invoice.form.fromPO.currency.confirmModal.heading" />}
               message={<FormattedMessage id="ui-invoice.invoice.form.fromPO.currency.confirmModal.message" />}

--- a/src/invoices/InvoiceForm/InvoiceForm.test.js
+++ b/src/invoices/InvoiceForm/InvoiceForm.test.js
@@ -342,7 +342,7 @@ describe('InvoiceForm component', () => {
 
       it.each([
         ['cancel', 'USD'],
-        ['submit', 'BYN'],
+        ['confirm', 'BYN'],
       ])('should handle "%s" action and set currency as "%s"', async (action, expectedValue) => {
         expect(screen.getByRole('button', { name: /currency/ })).toHaveValue('USD');
 
@@ -350,7 +350,7 @@ describe('InvoiceForm component', () => {
         await userEvent.click(screen.getByText(/BYN/));
         await userEvent.click(
           within(screen.getByRole('dialog', { name: /currency.confirmModal/ }))
-            .getByRole('button', { name: new RegExp(action) })
+            .getByRole('button', { name: new RegExp(action) }),
         );
 
         expect(screen.getByRole('button', { name: /currency/ })).toHaveValue(expectedValue);


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UINV-579

- Use "Confirm" word for submit;
- Display modal until user confirms it.

## Screenshot


https://github.com/user-attachments/assets/c4e32190-8eb0-4a75-81d4-552f543cb025

